### PR TITLE
fixed key hold class with timer elapse

### DIFF
--- a/include/key_hold.ngt
+++ b/include/key_hold.ngt
@@ -24,7 +24,7 @@ key_timer.restart();
 key_flag=0;
 return false;
 }
-int keytimerelapsed=key_timer.elapsed();
+int keytimerelapsed=key_timer.elapsed_millis();
 if(keytimerelapsed>=repeat_time)
 {
 switch(key_flag)


### PR DESCRIPTION
the key hold class has been fixed, because timer.elapsed does not exist, so it is changed to timer.elapsed_millis…psed method which does not exist